### PR TITLE
Document credentials addition

### DIFF
--- a/app/Http/Livewire/Documentation/Select.php
+++ b/app/Http/Livewire/Documentation/Select.php
@@ -131,7 +131,8 @@ class Select extends Component
     <x-select ...  :async-data="[
         'api' => route('api.users.index'),
         'method' => 'POST', // default is GET
-        'params' => ['ble' => 'baz'] // default is []
+        'params' => ['ble' => 'baz'], // default is []
+        'credentials' => 'include' // default is undefined
     ]" />
     HTML;
 

--- a/resources/views/livewire/documentation/select.blade.php
+++ b/resources/views/livewire/documentation/select.blade.php
@@ -95,7 +95,8 @@
             export type AsyncDataConfig = {
                 api: string | null
                 method: string
-                params: any
+                params: any,
+                credentials?: RequestCredentials,
                 alwaysFetch: boolean
             }
         </x-code>


### PR DESCRIPTION
This PR is to document the addition of the `credentials` option to the `async-data` prop from this PR: https://github.com/wireui/wireui/pull/476