### PR TITLE
Use the number input example instead of the password input example

### DIFF
--- a/app/Http/Livewire/Documentation/NumberInput.php
+++ b/app/Http/Livewire/Documentation/NumberInput.php
@@ -8,8 +8,8 @@ use Livewire\Component;
 
 class NumberInput extends Component
 {
-    public string $passwordExample = <<<HTML
-    <x-inputs.password label="Secret 🙈" value="I love WireUI ❤️" />
+    public string $numberExample = <<<HTML
+    <x-inputs.number label="How many Burgers?" />
     HTML;
 
     public string $holdExample = <<<HTML

--- a/resources/views/livewire/documentation/number-input.blade.php
+++ b/resources/views/livewire/documentation/number-input.blade.php
@@ -23,7 +23,7 @@
             href="#number-input"
             id="number-input"
             language="blade"
-            :code="$passwordExample">
+            :code="$numberExample">
             <div class="max-w-sm mx-auto">
                 <x-inputs.number label="How many Burgers?" />
             </div>


### PR DESCRIPTION
The number input docs page incorrectly shows the password input code example. This PR shows the correct number input code example.